### PR TITLE
mudança nos requisitos e criação de usuário admin

### DIFF
--- a/controle_estoque/Crud/Create.py
+++ b/controle_estoque/Crud/Create.py
@@ -75,12 +75,16 @@ class CreateDb(object):
                 Nivel(id=1, nivel='Vendedor'),
                 Nivel(id=2, nivel='Compras'),
                 Nivel(id=3, nivel='Financeiro'),
-                Nivel(id=4, nivel='Administrador'),
-                Usuarios(id=1, usuario='admin',
-                         senha='admin', nivel='4', ativo=1)
+                Nivel(id=4, nivel='Administrador')
             ])
 
             sessao.commit()
 
-        except:
+            sessao.add(Usuarios(id=1, usuario='admin',
+                         senha='admin', nivel=4, ativo=1))
+
+            sessao.commit()
+
+        except Exception as e:
+            print("ERRO: "+e)
             pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 PyQt5
-mysql-connector
+PyQtWebEngine
+mysql-connector-python
 jinja2
 pycep_correios
 mysqlclient


### PR DESCRIPTION
Um dos requisitos estava faltando para funcionar e o conector que funcionou aqui foi o connector-python. O usuário só permitia criação com nível já commitado no banco.