### PR TITLE
Correção da importação do Módulo de CEP

### DIFF
--- a/controle_estoque/Funcoes/Funcoes.py
+++ b/controle_estoque/Funcoes/Funcoes.py
@@ -7,10 +7,7 @@ from PyQt5.QtWidgets import QPushButton
 from PyQt5.QtCore import QSize
 from PyQt5.QtGui import QPixmap, QIcon
 
-
-from pycep_correios import get_address_from_cep
-from pycep_correios.exceptions import CEPNotFound, ConnectionError, InvalidCEP
-
+from brazilcep import get_address_from_cep, exceptions
 
 class Funcao(object):
 
@@ -108,9 +105,9 @@ class Funcao(object):
             self.tx_Numero.setFocus()
         except ConnectionError:
             self.tx_Endereco.setText('Sem conexão com serviço dos Correios')
-        except InvalidCEP:
+        except exceptions.InvalidCEP as eic:
             self.tx_Endereco.setText('CEP inválido')
-        except CEPNotFound:
+        except exceptions.CEPNotFound as ecnf:
             self.tx_Endereco.setText('CEP não encontrado')
         except:
             self.tx_Endereco.setText('Erro desconhecido')


### PR DESCRIPTION
### A partir de 1. de Maio de 2023,  a API "pycep-correios" passou a se chamar BrazilCEP, fazendo com que o programa não funcionasse direito devido ao erro de importação (já que o nome passou a ser completamente diferente).

Fiz as alterações necessárias tentando preservar a lógica do código. Segui as alterações descritas na documentação, que se encontra [nesta página](https://brazilcep.readthedocs.io/en/stable/tutorial/#errors-and-exceptions), na área de exceções, mais pro fim.



